### PR TITLE
replaced arquillian-graphene with graphene-webdriver

### DIFF
--- a/jboss-javaee-7.0-with-tools/pom.xml
+++ b/jboss-javaee-7.0-with-tools/pom.xml
@@ -120,7 +120,7 @@
                 allowing you to test AJAX more easily -->
             <dependency>
                 <groupId>org.jboss.arquillian.graphene</groupId>
-                <artifactId>arquillian-graphene</artifactId>
+                <artifactId>graphene-webdriver</artifactId>
                 <version>${version.org.jboss.arquillian.graphene}</version>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Hi, one more change in the Arquillian dependencies - I've replaced arquillian-graphene with graphene-webdriver as the arquillian-graphene depchain will be dropped - see ARQGRA-474