### PR TITLE
Updated versions of arquillian-core and ShrinkWrap Resolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
         <!-- Versions of JBoss projects -->
         <version.org.infinispan>8.0.1.Final</version.org.infinispan>
-        <version.org.jboss.arquillian>1.1.9.Final</version.org.jboss.arquillian>
+        <version.org.jboss.arquillian>1.1.10.Final</version.org.jboss.arquillian>
         <version.org.jboss.arquillian.extension.drone>1.3.1.Final</version.org.jboss.arquillian.extension.drone>
         <version.org.jboss.arquillian.graphene>2.0.3.Final</version.org.jboss.arquillian.graphene>
         <version.org.wildfly.arquillian.container>1.0.1.Final</version.org.wildfly.arquillian.container>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
         <!-- Versions of JBoss projects -->
         <version.org.infinispan>8.0.1.Final</version.org.infinispan>
-        <version.org.jboss.arquillian>1.1.8.Final</version.org.jboss.arquillian>
+        <version.org.jboss.arquillian>1.1.9.Final</version.org.jboss.arquillian>
         <version.org.jboss.arquillian.extension.drone>1.3.1.Final</version.org.jboss.arquillian.extension.drone>
         <version.org.jboss.arquillian.graphene>2.0.3.Final</version.org.jboss.arquillian.graphene>
         <version.org.wildfly.arquillian.container>1.0.1.Final</version.org.wildfly.arquillian.container>
@@ -83,8 +83,8 @@
         <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.resteasy>3.0.13.Final</version.org.jboss.resteasy>
         <version.org.jboss.security.negotiation>2.3.6.Final</version.org.jboss.security.negotiation>
-        <version.org.jboss.spec.jboss.javaee7>1.0.3.Final</version.org.jboss.spec.jboss.javaee7>
-        <version.org.jboss.shrinkwrap.resolver>2.1.1</version.org.jboss.shrinkwrap.resolver>
+        <version.org.jboss.spec.jboss.javaee.7.0>1.0.3.Final</version.org.jboss.spec.jboss.javaee.7.0>
+        <version.org.jboss.shrinkwrap.resolver>2.2.0</version.org.jboss.shrinkwrap.resolver>
         <version.org.picketlink>2.7.0.Final</version.org.picketlink>
 
         <!-- Version of Hibernate projects -->

--- a/wildfly-javaee7-with-tools/pom.xml
+++ b/wildfly-javaee7-with-tools/pom.xml
@@ -68,6 +68,16 @@
                 <version>${version.org.testng}</version>
             </dependency>
 
+            <!-- ShrinkWrap Resolvers project provides a Java API to obtain
+                artifacts from a repository system. -->
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                <artifactId>shrinkwrap-resolver-bom</artifactId>
+                <version>${version.org.jboss.shrinkwrap.resolver}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Arquillian lets test you your applications in real environment -->
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
@@ -128,16 +138,6 @@
                 <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-container-remote</artifactId>
                 <version>${version.org.wildfly.arquillian.container}</version>
-            </dependency>
-
-            <!-- Older versions of Shrinkwrap don't automatically manage
-                the version of Shrinkwrap depchain for us -->
-            <!-- TODO remove this when Arquillian upgrades to a newer shrinkwrap -->
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-depchain</artifactId>
-                <type>pom</type>
-                <version>${version.org.jboss.shrinkwrap.resolver}</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
arquillian-core to 1.1.9.Final
ShrinkWrap Resolver to 2.2.0 - there has been also replaced the depchain with the Resolver's BOM - to manage versions of transitive dependencies