### PR TITLE
[WFLY-11424] Add the wildfly-client-properties artifact

### DIFF
--- a/client/jms-client/pom.xml
+++ b/client/jms-client/pom.xml
@@ -188,6 +188,10 @@
             <artifactId>guava</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-client-properties</artifactId>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11424 is needed to fix the linked https://issues.jboss.org/browse/WFLY-11418 when used by the BOMs.

https://github.com/jbossas/jboss-eap7/pull/2881 (upstream: https://github.com/wildfly/wildfly/pull/11888) must be merged and released for this to work.

Sorry for creating the feature branch in the upstream repository. Feel free to delete it once merged