### PR TITLE
[WFLY-11862] banned dependency is now excluded at server dep management

### DIFF
--- a/client/jaxws-client/pom.xml
+++ b/client/jaxws-client/pom.xml
@@ -356,12 +356,6 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-tools-common</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.xml.bind</groupId>
-                    <artifactId>jaxb-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-11862