### PR TITLE
Update shrinkwrap-resolver to 2.2.7 to fix maven central https issue

### DIFF
--- a/jakartaee8/jakartaee8-with-tools/pom.xml
+++ b/jakartaee8/jakartaee8-with-tools/pom.xml
@@ -50,7 +50,7 @@
     <properties>
         <version.org.jboss.arquillian.extension.drone>2.3.1</version.org.jboss.arquillian.extension.drone>
         <version.org.jboss.arquillian.graphene>2.3.1</version.org.jboss.arquillian.graphene>
-        <version.org.jboss.shrinkwrap.resolver>2.2.6</version.org.jboss.shrinkwrap.resolver>
+        <version.org.jboss.shrinkwrap.resolver>2.2.7</version.org.jboss.shrinkwrap.resolver>
         <version.org.testng>6.11</version.org.testng>
     </properties>
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13209

I encountered some errors like:

	Could not transfer artifact org.jboss.remoting:jboss-remoting:jar:4.0.18.Final from/to central (http://repo1.maven.org/maven2):
	Error transferring file: Server returned HTTP response code: 501 for URL: 
	http://repo1.maven.org/maven2/org/jboss/remoting/jboss-remoting/4.0.18.Final/jboss-remoting-4.0.18.Final.jar 
	from http://repo1.maven.org/maven2/org/jboss/remoting/jboss-remoting/4.0.18.Final/jboss-remoting-4.0.18.Final.jar

when playing some quickstarts, I think upgrading `shrinkwrap-resolver` to [2.2.7](https://github.com/shrinkwrap/resolver/commits/2.2.7) should fix the [maven central https issue](https://github.com/shrinkwrap/resolver/commit/033e32b8484e1de2defda5b7b927600bdfbe105f).
