### PR TITLE
[WFLY-14720] update arquillian drone and graphene versions

### DIFF
--- a/jakartaee8/jakartaee8-with-tools/pom.xml
+++ b/jakartaee8/jakartaee8-with-tools/pom.xml
@@ -48,8 +48,8 @@
     </licenses>
 
     <properties>
-        <version.org.jboss.arquillian.extension.drone>2.3.1</version.org.jboss.arquillian.extension.drone>
-        <version.org.jboss.arquillian.graphene>2.3.1</version.org.jboss.arquillian.graphene>
+        <version.org.jboss.arquillian.extension.drone>2.5.2</version.org.jboss.arquillian.extension.drone>
+        <version.org.jboss.arquillian.graphene>2.3.2</version.org.jboss.arquillian.graphene>
         <version.org.jboss.shrinkwrap.resolver>2.2.7</version.org.jboss.shrinkwrap.resolver>
         <version.org.testng>6.11</version.org.testng>
     </properties>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14720
This partial fix of the issue updates BOMs to use latest versions of Arquillian Drone and Graphene, which fixes the incompatibility between Guava 23+ and older Selenium versions