### PR TITLE
[WFLY-17332] Fix narayana dependency, the correct artifact is again jbossxts

### DIFF
--- a/ee/pom.xml
+++ b/ee/pom.xml
@@ -366,10 +366,9 @@
                                     <artifactId>commons-logging-jboss-logging</artifactId>
                                 </dependency>
                                 <!-- include narayana -->
-                                <!-- replaces org.jboss.narayana.xts:jbossxts -->
                                 <dependency>
                                     <groupId>org.jboss.narayana.xts</groupId>
-                                    <artifactId>jbossxts-jakarta</artifactId>
+                                    <artifactId>jbossxts</artifactId>
                                     <classifier>api</classifier>
                                 </dependency>
                                 <!-- include resteasy -->


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17332

The `jbossxts-jakarta` artifact is no longer produced and the correct one is `jbossxts` again after Update to Narayana 6
https://github.com/wildfly/wildfly/pull/16464#issuecomment-1385368930