### PR TITLE
[WFLY-17545] Change infinispan artifact id to one actually wanted

### DIFF
--- a/ee/pom.xml
+++ b/ee/pom.xml
@@ -346,7 +346,7 @@
                                 <!-- include ispn -->                        
                                 <dependency>
                                     <groupId>org.infinispan</groupId>
-                                    <artifactId>infinispan-core</artifactId>
+                                    <artifactId>infinispan-core-jakarta</artifactId>
                                 </dependency>
                                 <!-- include jboss logging -->
                                 <dependency>


### PR DESCRIPTION
This is to fix the build with latest WildFly state which got broken after applying https://issues.redhat.com/browse/WFLY-17545. 

However, even though the issue revealed itself only now, this should have been changed already with the introduction of infinispan dependencies with "-jakarta" suffix in https://github.com/wildfly/wildfly/pull/16076 so IMHO 27.0.0.Final BOMs are incorrect too - it just didn't fail the build since due to legacy dependencies being available in WF it found the ones it wanted.