### PR TITLE
[WFLY-17879] Manage version of JUnit for wildfly-ee-with-tools BOM

### DIFF
--- a/ee/ee-with-tools/pom.xml
+++ b/ee/ee-with-tools/pom.xml
@@ -48,6 +48,7 @@
     </licenses>
 
     <properties>
+        <version.junit>4.13.2</version.junit>
         <version.org.jboss.arquillian.extension.drone>2.5.2</version.org.jboss.arquillian.extension.drone>
         <version.org.jboss.arquillian.graphene>2.3.2</version.org.jboss.arquillian.graphene>
         <version.org.jboss.shrinkwrap.resolver>2.2.7</version.org.jboss.shrinkwrap.resolver>
@@ -56,6 +57,13 @@
 
     <dependencyManagement>
         <dependencies>
+
+            <!-- Recommended JUnit version -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${version.junit}</version>
+            </dependency>
 
             <!-- Recommended TestNG version -->
             <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-17879

There was a change in how test dependencies are managed - https://issues.redhat.com/browse/WFLY-17561 and https://issues.redhat.com/browse/WFCORE-6203 and that caused the BOMs build to fail on missing JUnit version.

The proposal is not to rely on JUnit version being brought in transitively and instead explicitly manage it the same way we do with TestNG dependency version.

