### PR TITLE
[WFLY-18359] MP BOM doesn't contain io.opentelemetry:opentelemetry-context

### DIFF
--- a/microprofile/pom.xml
+++ b/microprofile/pom.xml
@@ -128,6 +128,10 @@
                                     <groupId>io.opentelemetry</groupId>
                                     <artifactId>opentelemetry-api</artifactId>
                                 </dependency>
+                                <dependency>
+                                    <groupId>io.opentelemetry</groupId>
+                                    <artifactId>opentelemetry-context</artifactId>
+                                </dependency>
                                 <!-- include jakarta specs APIs -->
                                 <dependency>
                                     <groupId>jakarta.enterprise</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-18359

Add dependency for opentelemetry-context